### PR TITLE
Fix Use of uninitialized value in division (/)

### DIFF
--- a/lib/LWP/Authen/OAuth2/AccessToken.pm
+++ b/lib/LWP/Authen/OAuth2/AccessToken.pm
@@ -85,8 +85,8 @@ sub should_refresh {
     my ($self, $early_refresh_time) = @_;
     # If the access tokens are short lived relative to $early_refresh_time
     # we cheat to avoid refreshing TOO often....
-    if ($self->{expires_in}/2 < $early_refresh_time) {
-        $early_refresh_time = $self->{expires_in}/2;
+    if ($self->expires_in/2 < $early_refresh_time) {
+        $early_refresh_time = $self->expires_in/2;
     }
     my $expires_in = $self->expires_in();
     if ($expires_in < $early_refresh_time) {


### PR DESCRIPTION
If 'expires_in' is not set by the remote api the dereferenced variable will not exist. The division works via the reference so dropping the braces gets rid of the 'Use of uninitialized value in division (/)' warnings.

``` bash
Use of uninitialized value in division (/) at /usr/local/share/perl/5.18.2/LWP/Authen/OAuth2/AccessToken.pm line 88.
Use of uninitialized value in division (/) at /usr/local/share/perl/5.18.2/LWP/Authen/OAuth2/AccessToken.pm line 89.
```
