### PR TITLE
With warnings enabled LWP::Useragent has unitialised variables

### DIFF
--- a/lib/LWP/Authen/OAuth2.pm
+++ b/lib/LWP/Authen/OAuth2.pm
@@ -81,7 +81,7 @@ sub init {
 # Standard shortcut request methods.
 sub delete {
     my ($self, @parameters) = @_;
-    my @rest = $self->user_agent->_process_colonic_headers(\@parameters);
+    my @rest = $self->user_agent->_process_colonic_headers(\@parameters,1);
     my $request = HTTP::Request::Common::DELETE(@parameters);
     return $self->request($request, @rest);
 }
@@ -95,21 +95,21 @@ sub get {
 
 sub head {
     my ($self, @parameters) = @_;
-    my @rest = $self->user_agent->_process_colonic_headers(\@parameters);
+    my @rest = $self->user_agent->_process_colonic_headers(\@parameters,1);
     my $request = HTTP::Request::Common::HEAD(@parameters);
     return $self->request($request, @rest);
 }
 
 sub post {
     my ($self, @parameters) = @_;
-    my @rest = $self->user_agent->_process_colonic_headers(\@parameters);
+    my @rest = $self->user_agent->_process_colonic_headers(\@parameters, (ref($parameters[1]) ? 2 : 1));
     my $request = HTTP::Request::Common::POST(@parameters);
     return $self->request($request, @rest);
 }
 
 sub put {
     my ($self, @parameters) = @_;
-    my @rest = $self->user_agent->_process_colonic_headers(\@parameters);
+    my @rest = $self->user_agent->_process_colonic_headers(\@parameters, (ref($parameters[1]) ? 2 : 1));
     my $request = HTTP::Request::Common::PUT(@parameters);
     return $self->request($request, @rest);
 }


### PR DESCRIPTION
It results in:

``` bash
Use of uninitialized value $i in numeric lt (<) at /home/leon/perl5/perlbrew/perls/perl-5.21.2/lib/site_perl/5.21.2/LWP/UserAgent.pm line 454.
Use of uninitialized value $i in array element at /home/leon/perl5/perlbrew/perls/perl-5.21.2/lib/site_perl/5.21.2/LWP/UserAgent.pm line 455.
Use of uninitialized value $i in array element at /home/leon/perl5/perlbrew/perls/perl-5.21.2/lib/site_perl/5.21.2/LWP/UserAgent.pm line 459.
Use of uninitialized value $i in array element at /home/leon/perl5/perlbrew/perls/perl-5.21.2/lib/site_perl/5.21.2/LWP/UserAgent.pm line 467.
Use of uninitialized value $i in array element at /home/leon/perl5/perlbrew/perls/perl-5.21.2/lib/site_perl/5.21.2/LWP/UserAgent.pm line 479.
```

OAuth2 provides all the common methods, but are missing all the start_index options.

OAuth2:

``` perl
sub post {
    my ($self, @parameters) = @_;
    my @rest = $self->user_agent->_process_colonic_headers(\@parameters);
    my $request = HTTP::Request::Common::POST(@parameters);
    return $self->request($request, @rest);
}
```

vs

LWP::UserAgent

``` perl
sub post {
    require HTTP::Request::Common;
    my($self, @parameters) = @_;
    my @suff = $self->_process_colonic_headers(\@parameters, (ref($parameters[1]) ? 2 : 1));
    return $self->request( HTTP::Request::Common::POST( @parameters ), @suff );
}
```

This pull request only covers 'get' so far, as I haven't got any test cases for the other methods (and I've not had a chance to figure out why 'make test' isn't running _all_ of the tests).
