### PR TITLE
Fix use test urls

### DIFF
--- a/lib/LWP/Authen/OAuth2/ServiceProvider.pm
+++ b/lib/LWP/Authen/OAuth2/ServiceProvider.pm
@@ -48,7 +48,7 @@ sub init {
     # In general subclasses should Just Work.
 
     # need to read this first, since the later opts depend on it
-    $self->copy_option($opts, 'use_test_urls');
+    $self->copy_option($opts, 'use_test_urls') if defined $opts->{use_test_urls};
 
     # These are required, NOT provided by this class, but are by subclasses.
     for my $field (qw(token_endpoint authorization_endpoint)) {

--- a/lib/LWP/Authen/OAuth2/ServiceProvider/Dwolla.pm
+++ b/lib/LWP/Authen/OAuth2/ServiceProvider/Dwolla.pm
@@ -39,4 +39,6 @@ sub default_api_headers {
 
 Adi Fairbank, C<< <https://github.com/adifairbank> >>
 
+=cut
+
 1;

--- a/t/LWP/Authen/OAuth2/ServiceProvider/Dwolla.t
+++ b/t/LWP/Authen/OAuth2/ServiceProvider/Dwolla.t
@@ -1,0 +1,22 @@
+#! /usr/bin/env perl
+use 5.006;
+use strict;
+use warnings FATAL => 'all';
+use Test::More;
+
+use FindBin qw($Bin);
+use lib "$Bin/../../../../../lib";
+
+BEGIN {
+    use_ok( 'LWP::Authen::OAuth2::ServiceProvider::Dwolla' ) || print "Bail out!\n";
+    use LWP::Authen::OAuth2;
+
+    my $oauth2 = LWP::Authen::OAuth2->new(
+        client_id => 'Test',
+        client_secret => 'Test',
+        service_provider => "Dwolla",
+    );
+    isa_ok($oauth2, 'LWP::Authen::OAuth2');
+}
+
+done_testing();

--- a/t/LWP/Authen/OAuth2/ServiceProvider/Google.t
+++ b/t/LWP/Authen/OAuth2/ServiceProvider/Google.t
@@ -9,6 +9,15 @@ use lib "$Bin/../../../../../lib";
 
 BEGIN {
     use_ok( 'LWP::Authen::OAuth2::ServiceProvider::Google' ) || print "Bail out!\n";
+    use LWP::Authen::OAuth2;
+
+    my $oauth2 = LWP::Authen::OAuth2->new(
+        client_id => 'Test',
+        client_secret => 'Test',
+        service_provider => "Google",
+        redirect_uri => "http://127.0.0.1",
+    );
+    isa_ok($oauth2, 'LWP::Authen::OAuth2');
 }
 
 done_testing();

--- a/t/LWP/Authen/OAuth2/ServiceProvider/Strava.t
+++ b/t/LWP/Authen/OAuth2/ServiceProvider/Strava.t
@@ -9,6 +9,15 @@ use lib "$Bin/../../../../../lib";
 
 BEGIN {
     use_ok( 'LWP::Authen::OAuth2::ServiceProvider::Strava' ) || print "Bail out!\n";
+    use LWP::Authen::OAuth2;
+
+    my $oauth2 = LWP::Authen::OAuth2->new(
+        client_id => 'Test',
+        client_secret => 'Test',
+        service_provider => "Strava",
+        redirect_uri => "http://127.0.0.1",
+    );
+    isa_ok($oauth2, 'LWP::Authen::OAuth2');
 }
 
 done_testing();


### PR DESCRIPTION
Recent lib change broke `LWP::Authen::OAuth2::ServiceProvider::Strava` and `LWP::Authen::OAuth2::ServiceProvider::Google`.

It should be optional as the Dwolla service provider defaults to 'www.dwolla.com' and test urls are not used by other service providers.

Added some basic instantiation tests and fixed a small issue with Dwolla.pm