### PR TITLE
Add LINE support

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -8,6 +8,8 @@ lib/LWP/Authen/OAuth2/Overview.pod
 lib/LWP/Authen/OAuth2/ServiceProvider.pm
 lib/LWP/Authen/OAuth2/ServiceProvider/Dwolla.pm
 lib/LWP/Authen/OAuth2/ServiceProvider/Google.pm
+lib/LWP/Authen/OAuth2/ServiceProvider/Line.pm
+lib/LWP/Authen/OAuth2/ServiceProvider/Line/AccessToken.pm
 lib/LWP/Authen/OAuth2/ServiceProvider/Strava.pm
 Makefile.PL
 MANIFEST			This list of files
@@ -19,6 +21,8 @@ t/LWP/Authen/OAuth2/AccessToken/Bearer.t
 t/LWP/Authen/OAuth2/Args.t
 t/LWP/Authen/OAuth2/ServiceProvider.t
 t/LWP/Authen/OAuth2/ServiceProvider/Google.t
+t/LWP/Authen/OAuth2/ServiceProvider/Line.t
+t/LWP/Authen/OAuth2/ServiceProvider/Line/AccessToken.t
 t/LWP/Authen/OAuth2/ServiceProvider/Strava.t
 t/manifest.t
 t/pod.t

--- a/lib/LWP/Authen/OAuth2.pm
+++ b/lib/LWP/Authen/OAuth2.pm
@@ -59,22 +59,7 @@ sub init {
     $self->copy_option(\%opts, "user_agent", undef);
 
     if ($self->{token_string}) {
-        # Probably not the object that I need in access_token.
-        my $tokens = eval{ decode_json($self->{token_string}) };
-        if ($@) {
-            croak("While decoding token_string: $@");
-        }
-
-        my $class = $tokens->{_class}
-            or croak("No _class in token_string '$self->{token_string}'");
-
-        eval {load($class)};
-        if ($@) {
-            croak("Can't load access token class '$class': $@");
-        }
-
-        # I will assume this works.
-        $self->{access_token} = $class->from_ref($tokens);
+        $self->load_token_string();
     }
 }
 
@@ -313,6 +298,28 @@ sub set_user_agent {
     $self->{user_agent} = $agent;
 }
 
+sub load_token_string {
+    my ($self, $token_string) = @_;
+    $token_string ||= $self->{token_string};
+
+    # Probably not the object that I need in access_token.
+    my $tokens = eval{ decode_json($token_string) };
+    if ($@) {
+        croak("While decoding token_string: $@");
+    }
+
+    my $class = $tokens->{_class}
+        or croak("No _class in token_string '$token_string'");
+
+    eval {load($class)};
+    if ($@) {
+        croak("Can't load access token class '$class': $@");
+    }
+
+    # I will assume this works.
+    $self->{access_token} = $class->from_ref($tokens);
+}
+
 sub user_agent {
     my $self = shift;
     return $self->{user_agent} ||= LWP::UserAgent->new();
@@ -356,21 +363,27 @@ Currently L<LWP::Authen::OAuth2> provides ready-to-use classes to use OAuth2 wit
 
 =over
 
+=item * Dwolla
+
+L<LWP::Authen::OAuth2::ServiceProvider::Dwolla>
+
+implemented by L<Adi Fairbank|https://github.com/adifairbank>
+
 =item * Google
 
-LWP::Authen::OAuth2::ServiceProvider::Google
+L<LWP::Authen::OAuth2::ServiceProvider::Google>
+
+=item * Line
+
+L<LWP::Authen::OAuth2::ServiceProvider::Line>
+
+implemented by L<Adam Millerchip|https://github.com/amillerchip>
 
 =item * Strava
 
-LWP::Authen::OAuth2::ServiceProvider::Strava
+L<LWP::Authen::OAuth2::ServiceProvider::Strava>
 
 implemented by L<Leon Wright|https://github.com/techman83>
-
-=item * Dwolla
-
-LWP::Authen::OAuth2::ServiceProvider::Dwolla
-
-implemented by L<Adi Fairbank|https://github.com/adifairbank>
 
 =back
 

--- a/lib/LWP/Authen/OAuth2/ServiceProvider.pm
+++ b/lib/LWP/Authen/OAuth2/ServiceProvider.pm
@@ -464,7 +464,13 @@ hopefully useful configuration and documentation:
 
 =over 4
 
+=item L<LWP::Authen::OAuth2::ServiceProvider::Dwolla|Dwolla>
+
 =item L<LWP::Authen::OAuth2::ServiceProvider::Google|Google>
+
+=item L<LWP::Authen::OAuth2::ServiceProvider::Line|Line>
+
+=item L<LWP::Authen::OAuth2::ServiceProvider::Strava|Strava>
 
 =back
 

--- a/lib/LWP/Authen/OAuth2/ServiceProvider/Line.pm
+++ b/lib/LWP/Authen/OAuth2/ServiceProvider/Line.pm
@@ -77,7 +77,7 @@ LWP::Authen::OAuth2::ServiceProvider::Line - Access Line OAuth2 API v2
         client_secret    => 'line_client_secret'  # Retrieved from https://developers.line.me/
     );
 
-    my $url = $oauth2->authorization_url();
+    my $url = $oauth2->authorization_url(state => $state);
 
     # ... Send user to authorization URL and get authorization $code ...
 

--- a/lib/LWP/Authen/OAuth2/ServiceProvider/Line.pm
+++ b/lib/LWP/Authen/OAuth2/ServiceProvider/Line.pm
@@ -1,0 +1,155 @@
+package LWP::Authen::OAuth2::ServiceProvider::Line;
+
+use strict;
+use warnings;
+
+use parent 'LWP::Authen::OAuth2::ServiceProvider';
+
+sub required_init {
+    return qw(client_id client_secret redirect_uri);
+}
+
+sub authorization_required_params {
+    return qw(client_id redirect_uri response_type state);
+}
+
+sub authorization_default_params {
+    return response_type => 'code';
+}
+
+sub request_required_params {
+    return qw(client_id redirect_uri grant_type client_secret code);
+}
+
+sub request_default_params {
+    return grant_type => 'authorization_code';
+}
+
+sub init {
+    my ($self, $opts) = @_;
+    $self->copy_option($opts, line_server => 'line.me');
+    $self->SUPER::init($opts);
+}
+
+sub authorization_endpoint {
+    my $self = shift;
+    my $server = $self->{line_server} or die 'line_server not configured. Forgot to call init()?';
+
+    return "https://access.$server/dialog/oauth/weblogin";
+}
+
+sub token_endpoint {
+    my $self = shift;
+    my $server = $self->{line_server} or die 'line_server not configured. Forgot to call init()?';
+
+    return "https://api.$server/v2/oauth/accessToken";
+}
+
+sub api_url_base {
+    my $self = shift;
+    my $server = $self->{line_server} or die 'line_server not configured. Forgot to call init()?';
+
+    return "https://api.$server/v2/";
+}
+
+sub access_token_class {
+    my ($self, $type) = @_;
+
+    if ($type eq 'bearer') {
+        return 'LWP::Authen::OAuth2::ServiceProvider::Line::AccessToken';
+    }
+
+    return $self->SUPER::access_token_class($type);
+}
+
+=pod
+
+=head1 NAME
+
+LWP::Authen::OAuth2::ServiceProvider::Line - Access Line OAuth2 API v2
+
+=head1 SYNOPSIS
+
+    my $oauth2 = LWP::Authen::OAuth2->new(
+        service_provider => 'Line',
+        redirect_uri     => 'http://example.com/',
+        client_id        => 'line_client_id'      # Retrieved from https://developers.line.me/
+        client_secret    => 'line_client_secret'  # Retrieved from https://developers.line.me/
+    );
+
+    my $url = $oauth2->authorization_url();
+
+    # ... Send user to authorization URL and get authorization $code ...
+
+    $oauth2->request_tokens(code => $code);
+
+    # Simple requests
+
+    # User Info
+    my $profile       = $oauth2->make_api_call('profile');
+    my $userId        = $profile->{userId};
+    my $displayName   = $profile->{displayName};
+    my $pictureUrl    = $profile->{pictureUrl};
+    my $statusMessage = $profile->{statusMessage};
+
+    # Refresh
+    $oauth2->refresh_access_token();
+
+    # More complex requests...
+
+    # Verify
+    # Manually send the request using the internal user agent - see explanation in "Line API Documentation" below.
+    my $access_token_str = $oauth2->access_token->access_token;
+    my $res = $oauth2->user_agent->post($oauth2->api_url_base.'oauth/verify' => { access_token => $access_token_str });
+    my $content = eval { decode_json($res->content) };
+    my $scope      = $content->{scope};
+    my $client_id  = $content->{client_id};
+    my $expires_in = $content->{expires_in};
+
+    # Revoke
+    # Look up the internal refresh token - see explanation in "Line API Documentation" below.
+    my $refresh_token_str = $oauth2->access_token->refresh_token;
+    $oauth2->post($oauth2->api_url_base.'oauth/revoke' => { refresh_token => $refresh_token_str });
+
+=head1 REGISTERING
+
+Individual users must have an account created with the L<Line application|https://line.me/download>.  In order to log in with OAuth2, users must register their email address. Device-specific instructions can be found on the L<Line support site|https://help.line.me/>.
+
+API clients can follow the L<Line Login|https://developers.line.me/line-login/overview> documentation to set up the OAuth2 credentials.
+
+=head1 Line API Documentation
+
+See the Line L<Social REST API Reference|https://devdocs.line.me/en/#how-to-use-the-apis>.
+
+As of writing, there are two simple API calls: C<profile> and C<refresh>.
+
+There are also C<verify> and C<revoke> endpoints, which require a bit more work.
+
+=over
+
+=item C<verify>
+
+C<verify> is designed for verifying pre-existing access tokens. Instead of using the C<Authorization> header, this endpoint expects the access token to be form-urlencoded in the request body. Because of this, it's necessary to get access to the internal access token string to send in the request body. The L<LWP::Authen::OAuth2::ServiceProvider::Line::AccessToken> token class used by this service provider provides the C<access_token> accessor for this purpose.
+
+The server seems to ignore the C<Authorization> header for this request, so including it is probably not a problem. If you want to avoid sending the access token in the header, it's necessary to manually construct the request and decode the response.
+
+See L</SYNOPSYS> for usage examples.
+
+=item C<revoke>
+
+C<revoke> requires the refresh token to be form-urlencoded in the request body. Because of this, it's necessary to get access to the internal refresh token string to send in the request body. The L<LWP::Authen::OAuth2::ServiceProvider::Line::AccessToken> token class used by this service provider provides the C<refresh_token> accessor for this purpose. See L</SYNOPSYS> for usage examples.
+
+=back
+
+=head1 Refresh timing
+
+Line access tokens can be refreshed at any time up until 10 days after the access token expires. The L<LWP::Authen::OAuth2::ServiceProvider::Line::AccessToken> token class used by this service provider extends the C<should_refresh> method for this purpose, causing C<< $oauth2->should_refresh() >> to return false if this 10-day period has lapsed.
+
+=head1 AUTHOR
+
+Adam Millerchip, C<< <adam at millerchip.net> >>
+
+=cut
+
+1;
+

--- a/lib/LWP/Authen/OAuth2/ServiceProvider/Line/AccessToken.pm
+++ b/lib/LWP/Authen/OAuth2/ServiceProvider/Line/AccessToken.pm
@@ -1,0 +1,25 @@
+package LWP::Authen::OAuth2::ServiceProvider::Line::AccessToken;
+
+use strict;
+use warnings;
+use parent 'LWP::Authen::OAuth2::AccessToken::Bearer';
+
+our $REFRESH_PERIOD = 864000; # 10 days. https://devdocs.line.me/en/#refreshing-access-tokens
+
+# Line tokens can be refreshed until the refresh period is over.
+sub should_refresh {
+    my ($self, @args) = @_;
+
+    return 0 unless $self->SUPER::should_refresh(@args);
+
+    my $refresh_expires_time = $self->expires_time + $REFRESH_PERIOD;
+    my $refresh_token_valid = time < $refresh_expires_time;
+
+    return $refresh_token_valid;
+}
+
+# These are exposed for use with /oauth/verify and /oauth/revoke API requests
+sub access_token  { shift->{access_token}  }
+sub refresh_token { shift->{refresh_token} }
+
+1;

--- a/t/LWP/Authen/OAuth2/ServiceProvider/Line.t
+++ b/t/LWP/Authen/OAuth2/ServiceProvider/Line.t
@@ -1,0 +1,29 @@
+#! /usr/bin/env perl
+use 5.006;
+use strict;
+use warnings FATAL => 'all';
+use Test::More;
+
+use FindBin qw($Bin);
+use lib "$Bin/../../../../../lib";
+
+BEGIN {
+    use_ok( 'LWP::Authen::OAuth2::ServiceProvider::Line' ) || print "Bail out!\n";
+    use LWP::Authen::OAuth2;
+
+    my $oauth2 = LWP::Authen::OAuth2->new(
+        client_id => 'Test',
+        client_secret => 'Test',
+        service_provider => 'Line',
+        redirect_uri => 'http://127.0.0.1',
+    );
+    isa_ok($oauth2, 'LWP::Authen::OAuth2');
+
+    my $sp = $oauth2->{service_provider};
+    is($sp->api_url_base                 => 'https://api.line.me/v2/'                                );
+    is($sp->token_endpoint               => 'https://api.line.me/v2/oauth/accessToken'               );
+    is($sp->authorization_endpoint       => 'https://access.line.me/dialog/oauth/weblogin'           );
+    is($sp->access_token_class('bearer') => 'LWP::Authen::OAuth2::ServiceProvider::Line::AccessToken');
+}
+
+done_testing();

--- a/t/LWP/Authen/OAuth2/ServiceProvider/Line/AccessToken.t
+++ b/t/LWP/Authen/OAuth2/ServiceProvider/Line/AccessToken.t
@@ -1,0 +1,46 @@
+#! /usr/bin/env perl
+use 5.006;
+use strict;
+use warnings FATAL => 'all';
+use Test::More;
+
+use FindBin qw($Bin);
+use lib "$Bin/../../../../../../lib";
+
+BEGIN {
+    use_ok( 'LWP::Authen::OAuth2::ServiceProvider::Line::AccessToken' ) || print "Bail out!\n";
+}
+
+is($LWP::Authen::OAuth2::ServiceProvider::Line::AccessToken::REFRESH_PERIOD, 10*24*60*60);
+
+my $token = LWP::Authen::OAuth2::ServiceProvider::Line::AccessToken->from_ref({
+    expires_in    =>  60,
+    access_token  => 'dummy_access_token',
+    refresh_token => 'dummy_refresh_token',
+    _class        => 'LWP::Authen::OAuth2::ServiceProvider::Line::AccessToken',
+});
+is(ref $token, 'LWP::Authen::OAuth2::ServiceProvider::Line::AccessToken');
+is($token->access_token,  'dummy_access_token' );
+is($token->refresh_token, 'dummy_refresh_token');
+ok(!$token->should_refresh(0), 'not expired');
+
+$token = LWP::Authen::OAuth2::ServiceProvider::Line::AccessToken->from_ref({
+    expires_in    =>  -60,
+    access_token  => 'dummy_access_token',
+    refresh_token => 'dummy_refresh_token',
+    _class        => 'LWP::Authen::OAuth2::ServiceProvider::Line::AccessToken',
+});
+ok($token->should_refresh(0), 'expired, refreshable');
+
+$token = LWP::Authen::OAuth2::ServiceProvider::Line::AccessToken->from_ref({
+    expires_in    =>  -1_000_000,
+    access_token  => 'dummy_access_token',
+    refresh_token => 'dummy_refresh_token',
+    _class        => 'LWP::Authen::OAuth2::ServiceProvider::Line::AccessToken',
+});
+ok(!$token->should_refresh(0), 'expired, not refreshable');
+
+local $LWP::Authen::OAuth2::ServiceProvider::Line::AccessToken::REFRESH_PERIOD = 2_000_000;
+ok($token->should_refresh(0), 'REFRESH_PERIOD global is obeyed');
+
+done_testing();


### PR DESCRIPTION
This PR adds support for using OAuth2 with LINE.

See https://developers.line.me/web-api/integrating-web-login-v2.

Besides the new service provider, I moved `OAuth2`'s logic for parsing an existing token string out of `init` and into a separate method. This is because it's useful to be able to call it after initialization.