### PR TITLE
Update the code to match what's on CPAN

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for LWP-Authen-OAuth2
 
+0.14	2017-08-16T08:18:46
+   - released on CPAN-Day 2017 from Sibiu, Romania
+   - Add Service Provider for Line (Adam Millerchip)
+
+
 0.13    2016-11-21T15:08:43
     - Add documentation for some new methods, and for Dwolla (Adi Fairbank)
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -20,6 +20,7 @@ t/LWP/Authen/OAuth2/AccessToken.t
 t/LWP/Authen/OAuth2/AccessToken/Bearer.t
 t/LWP/Authen/OAuth2/Args.t
 t/LWP/Authen/OAuth2/ServiceProvider.t
+t/LWP/Authen/OAuth2/ServiceProvider/Dwolla.t
 t/LWP/Authen/OAuth2/ServiceProvider/Google.t
 t/LWP/Authen/OAuth2/ServiceProvider/Line.t
 t/LWP/Authen/OAuth2/ServiceProvider/Line/AccessToken.t

--- a/lib/LWP/Authen/OAuth2.pm
+++ b/lib/LWP/Authen/OAuth2.pm
@@ -335,7 +335,7 @@ Version 0.13
 
 =cut
 
-our $VERSION = '0.13';
+our $VERSION = '0.14';
 
 
 =head1 SYNOPSIS


### PR DESCRIPTION
It looks like the last release to CPAN hasn't quite made it onto github.  This adds a commit, to make it match, and then the next one updates the MANIFEST to include the extra test in the source code but not previously included in the distribution.