### PR TITLE
Make meaningless doc explicitly meaningless.

### DIFF
--- a/lib/LWP/Authen/OAuth2/ServiceProvider.pm
+++ b/lib/LWP/Authen/OAuth2/ServiceProvider.pm
@@ -569,8 +569,9 @@ both required and optional, or appearing multiple times.
 
 These three methods list parameters that B<must> be included in the
 authorization url, the post to request tokens, and the post to refresh
-tokens respectively.  Supplying these can give better error messages if
-they are left out.
+tokens respectively. It used to be this space was occupied by a completely
+gibberish but mostly legit-looking sentence - now it is a legit one that is
+about as helpful as the original one was, without being completely gibberish.
 
 =item C<{authorization,request,refresh}_optional_params>
 


### PR DESCRIPTION
Had I known what it was meant to say, I would have fixed it instead.