### PR TITLE
Update name of contributor

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ Get the user agent.  The default if none was explicitly set is a new
 
 - [Leon Wright](https://github.com/techman83)
 - [Thomas Klausner](https://github.com/domm)
-- [Alexander Dutton](https://github.com/alexsdutton)
+- [Alex Dutton](https://github.com/alexdutton)
 - [Chris](https://github.com/TheWatcher)
 - [Adi Fairbank](https://github.com/adifairbank)
 - [Adam Millerchip](https://github.com/amillerchip)
@@ -454,7 +454,7 @@ Thanks to
 - [Thomas Klausner](https://github.com/domm) for reporting that client
 type specific parameters were not available when the client type was properly
 specified
-- [Alexander Dutton](https://github.com/alexsdutton) for making
+- [Alex Dutton](https://github.com/alexdutton) for making
 `ServiceProvider` work without requiring subclassing.
 - [Leon Wright](https://github.com/techman83) for adding a [Strava ](https://metacpan.org/pod/%20http%3A#strava.com) Service Provider and various bug fixes
 - [Adi Fairbank](https://github.com/adifairbank) for adding a [Dwolla ](https://metacpan.org/pod/%20https%3A#www.dwolla.com) Service Provider and some other improvements


### PR DESCRIPTION
Hiya. I was a contributor a long time ago, and now go by another name. I've also changed my GitHub username — the previous [GitHub username](https://github.com/alexsdutton) is now a way-finder for my [current one](https://github.com/alexdutton).

Many thanks for maintaining contributor information!